### PR TITLE
Ensure children of the selected Root Category are returned

### DIFF
--- a/src/fields/formfields/Categories.php
+++ b/src/fields/formfields/Categories.php
@@ -287,11 +287,11 @@ class Categories extends CraftCategories implements FormFieldInterface
             if ($this->rootCategory instanceof ElementQueryInterface) {
                 $ids = $this->rootCategory->id;
             } else {
-                $ids = ArrayHelper::getColumn($this->rootCategory, 'id');
+                $ids = ArrayHelper::getValue($this->rootCategory, '0.id');
             }
 
             if ($ids) {
-                $query->id($ids);
+                $query->descendantOf($ids);
             }
         }
 


### PR DESCRIPTION
The relevant PR for https://github.com/verbb/formie/issues/1111 —

Two changes:
- Ensures the value returned by the call to ArrayHelper results in a distinct value instead of an Array
- Ensures the element criteria result in the children of the root being returned as field options, instead of the Root itself